### PR TITLE
Add reflective logging modules

### DIFF
--- a/mirror_log/__init__.py
+++ b/mirror_log/__init__.py
@@ -1,0 +1,5 @@
+"""Enable mirror_log to be imported as a module."""
+
+# Provide references to markdown resources
+log_sample = "log_sample.md"
+self_audit_template = "self_audit_template.md"

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,30 @@
-# Humanity Mirror Core Agent
+from mirror_log import log_sample, self_audit_template
+from vaultfire import rewards
+from memory_graph import update_graph
+from moral_alignment import evaluate_entry
+import datetime
 
-def main():
-    print("👁️ Ghostkey: Humanity Mirror initialized.")
-    print("Ready for daily reflections...")
+
+def get_user_input():
+    print("💠 Welcome to Humanity Mirror")
+    print("1. Daily Reflection  2. Self-Audit  3. Exit")
+    choice = input("Choose (1/2/3): ")
+
+    if choice == "1":
+        entry = input("Reflect freely (feelings, choices, doubts):\n")
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        with open("mirror_log/log_sample.md", "a") as f:
+            f.write(f"\n## {timestamp}\n{entry}\n")
+        update_graph(entry)
+        evaluate_entry(entry)
+        rewards.calculate(entry)
+
+    elif choice == "2":
+        with open("mirror_log/self_audit_template.md", "r") as f:
+            print(f.read())
+    else:
+        print("Goodbye.")
+
 
 if __name__ == "__main__":
-    main()
-
+    get_user_input()

--- a/src/memory_graph.py
+++ b/src/memory_graph.py
@@ -1,0 +1,3 @@
+def update_graph(entry):
+    # Simulate emotional graph node tagging (to be expanded later)
+    print("🧠 Memory graph updated: entry logged for future moral map.")

--- a/src/moral_alignment.py
+++ b/src/moral_alignment.py
@@ -1,0 +1,4 @@
+def evaluate_entry(entry):
+    keywords = ["honest", "grateful", "selfish", "hopeful", "afraid"]
+    score = sum(1 for word in keywords if word in entry.lower())
+    print(f"🧭 Moral alignment score: {score}/5 — Integrity signal logged.")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,5 @@
+import datetime
+
+
+def get_timestamp():
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
## Summary
- expand `main` into an interactive CLI that records reflections, updates a memory graph, evaluates moral alignment, and issues rewards
- add support modules for memory graph updates, moral alignment scoring, and timestamp utilities
- make `mirror_log` importable so markdown logs can be referenced as resources

## Testing
- `python -m py_compile src/main.py src/memory_graph.py src/moral_alignment.py src/utils.py mirror_log/__init__.py`
- `PYTHONPATH=. python src/main.py` then chose option 3 to exit


------
https://chatgpt.com/codex/tasks/task_e_6892cf7fb0688322a7ade9e6bce8c7c9