### PR TITLE
Add dashboard and reward simulation

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,26 @@
+async function loadData() {
+    const res = await fetch('/data');
+    const data = await res.json();
+
+    const timeline = document.getElementById('timeline');
+    timeline.innerHTML = '';
+    data.reflections.forEach((r, i) => {
+        const li = document.createElement('li');
+        li.textContent = `${i + 1}. ${r.text} [${r.sentiment}] (${r.traits.join(', ')})`;
+        timeline.appendChild(li);
+    });
+
+    document.getElementById('integrity').textContent = data.integrity_score;
+
+    const cloud = document.getElementById('trait-cloud');
+    cloud.innerHTML = '';
+    Object.entries(data.trait_cloud).forEach(([trait, count]) => {
+        const span = document.createElement('span');
+        span.textContent = `${trait}(${count})`;
+        cloud.appendChild(span);
+    });
+
+    document.getElementById('yield').textContent = data.vaultfire_yield;
+}
+
+document.addEventListener('DOMContentLoaded', loadData);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Humanity Mirror Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Humanity Mirror Dashboard</h1>
+    <section>
+        <h2>Reflection Timeline</h2>
+        <ul id="timeline"></ul>
+    </section>
+    <section>
+        <h2>Integrity Score</h2>
+        <div id="integrity">0</div>
+    </section>
+    <section>
+        <h2>Moral Trait Cloud</h2>
+        <div id="trait-cloud"></div>
+    </section>
+    <section>
+        <h2>Vaultfire Yield Preview</h2>
+        <div id="yield"></div>
+    </section>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -1,0 +1,17 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background: #f4f4f4;
+}
+
+section {
+    background: #fff;
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+}
+
+#trait-cloud span {
+    margin-right: 8px;
+    font-size: 14px;
+}

--- a/run_dashboard.py
+++ b/run_dashboard.py
@@ -1,0 +1,53 @@
+"""Flask server to preview Humanity Mirror dashboard."""
+
+from flask import Flask, jsonify, send_from_directory
+
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from memory_graph import get_memory_graph
+from vaultfire.rewards import get_last_signal
+from vaultfire.simulator import simulate_passive_yield
+
+app = Flask(__name__, static_folder="dashboard")
+
+
+@app.route("/")
+def index():
+    return send_from_directory("dashboard", "index.html")
+
+
+@app.route("/<path:path>")
+def static_files(path):
+    return send_from_directory("dashboard", path)
+
+
+@app.route("/data")
+def data():
+    graph = get_memory_graph()
+    integrity_score = sum(node["score"] for node in graph)
+
+    trait_cloud = {}
+    for node in graph:
+        for trait in node["traits"]:
+            trait_cloud[trait] = trait_cloud.get(trait, 0) + 1
+
+    frequency = len(graph)
+    vaultfire_signal = get_last_signal() or simulate_passive_yield(
+        integrity_score, frequency
+    )
+
+    return jsonify(
+        {
+            "reflections": graph,
+            "integrity_score": integrity_score,
+            "trait_cloud": trait_cloud,
+            "vaultfire_yield": vaultfire_signal,
+        }
+    )
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/memory_graph.py
+++ b/src/memory_graph.py
@@ -1,3 +1,63 @@
-def update_graph(entry):
-    # Simulate emotional graph node tagging (to be expanded later)
+"""Simple in-memory graph with sentiment and trait tagging."""
+
+from typing import Dict, List
+
+# Store all reflections with their analysis for later dashboard use
+_MEMORY_GRAPH: List[Dict[str, object]] = []
+
+# Keyword based mapping for quick trait extraction
+_TRAIT_KEYWORDS = {
+    "honesty": ["honest", "truth", "transparent"],
+    "compassion": ["compassion", "empathy", "kind"],
+    "fear": ["fear", "afraid", "scared", "anxious"],
+    "doubt": ["doubt", "uncertain", "unsure"],
+}
+
+_POSITIVE = {"honesty", "compassion"}
+_NEGATIVE = {"fear", "doubt"}
+
+
+def _analyze(entry: str) -> Dict[str, object]:
+    """Return sentiment and moral traits for an entry."""
+
+    text = entry.lower()
+
+    traits = [
+        trait
+        for trait, keywords in _TRAIT_KEYWORDS.items()
+        if any(word in text for word in keywords)
+    ]
+
+    positive_hits = any(word in text for word in ["good", "great", "love"])
+    negative_hits = any(word in text for word in ["bad", "terrible", "hate"])
+    sentiment = "neutral"
+    if positive_hits and not negative_hits:
+        sentiment = "positive"
+    elif negative_hits and not positive_hits:
+        sentiment = "negative"
+
+    score = sum(1 for t in traits if t in _POSITIVE) - sum(
+        1 for t in traits if t in _NEGATIVE
+    )
+
+    return {
+        "text": entry,
+        "sentiment": sentiment,
+        "traits": traits,
+        "score": score,
+    }
+
+
+def update_graph(entry: str) -> Dict[str, object]:
+    """Analyze entry and append to the memory graph."""
+
+    node = _analyze(entry)
+    _MEMORY_GRAPH.append(node)
     print("🧠 Memory graph updated: entry logged for future moral map.")
+    return node
+
+
+def get_memory_graph() -> List[Dict[str, object]]:
+    """Return all recorded memory graph nodes."""
+
+    return list(_MEMORY_GRAPH)

--- a/vaultfire/rewards.py
+++ b/vaultfire/rewards.py
@@ -1,4 +1,29 @@
-# Integrity-based reward logic placeholder
+"""Reward helpers hooking into the Vaultfire simulator."""
 
-def calculate_yield(user_log):
-    return "💎 Loyalty points calculated (stub)."
+from typing import List
+
+from .simulator import simulate_passive_yield
+from memory_graph import get_memory_graph
+
+_reflections: List[str] = []
+_last_signal: str = ""
+
+
+def calculate(entry: str) -> str:
+    """Update reflection history and emit a reward signal."""
+
+    global _last_signal
+    _reflections.append(entry)
+
+    graph = get_memory_graph()
+    trait_score = graph[-1]["score"] if graph else 0
+    frequency = len(_reflections)
+    _last_signal = simulate_passive_yield(trait_score, frequency)
+    print(_last_signal)
+    return _last_signal
+
+
+def get_last_signal() -> str:
+    """Return the most recent simulated reward signal."""
+
+    return _last_signal

--- a/vaultfire/simulator.py
+++ b/vaultfire/simulator.py
@@ -1,0 +1,15 @@
+"""Vaultfire reward simulation utilities."""
+
+
+def simulate_passive_yield(trait_score: int, reflection_frequency: int) -> str:
+    """Return a mock passive yield signal.
+
+    The yield is a simple combination of moral trait score and the
+    number of reflections submitted. Positive traits boost the base
+    while frequent reflections add a compounding bonus.
+    """
+
+    base = max(trait_score, 0) * 0.1
+    bonus = reflection_frequency * 0.05
+    total = round(base + bonus, 2)
+    return f"\U0001F506 Simulated yield: {total} pts"


### PR DESCRIPTION
## Summary
- add HTML/JS dashboard for timeline, integrity score, trait cloud, and Vaultfire preview
- extend memory graph with sentiment and moral trait tagging
- simulate passive reward signals and expose via Flask server

## Testing
- `python run_dashboard.py`
- `pytest src/`
- `pytest vaultfire/`


------
https://chatgpt.com/codex/tasks/task_e_6892d0f4a3808322bb613344356f007c