### PR TITLE
feat: add identity anchoring and exportable belief proof

### DIFF
--- a/identity/bridge.py
+++ b/identity/bridge.py
@@ -1,0 +1,43 @@
+"""Identity bridge linking reflections and reward signals to anchors."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from memory_graph import get_memory_graph
+from vaultfire import rewards
+
+
+def generate_belief_certificate(
+    ens: str, cb_id: str, biometric_hash: Optional[str] = None
+) -> Dict[str, object]:
+    """Return a belief certificate with identity anchors and history.
+
+    Parameters
+    ----------
+    ens: str
+        ENS tag for the user (e.g. ``ghostkey316.eth``).
+    cb_id: str
+        cb.id tag for the user (e.g. ``bpow20.cb.id``).
+    biometric_hash: Optional[str]
+        Placeholder for future biometric syncs.
+    """
+
+    graph: List[Dict[str, object]] = get_memory_graph()
+    recent_reflections = [node["text"] for node in graph[-3:]]
+    integrity_score = sum(node["score"] for node in graph[-3:]) if graph else 0
+
+    certificate = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "ens": ens,
+        "cb_id": cb_id,
+        "biometric_hash": biometric_hash,
+        "integrity_score": integrity_score,
+        "recent_reflections": recent_reflections,
+        "reward_signal": rewards.get_last_signal(),
+    }
+    return certificate
+
+
+__all__ = ["generate_belief_certificate"]

--- a/identity/exporter.py
+++ b/identity/exporter.py
@@ -1,0 +1,62 @@
+"""Utilities for exporting belief certificates to disk."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List
+
+from memory_graph import get_memory_graph
+from vaultfire import rewards
+from vaultfire.simulator import simulate_passive_yield
+
+
+def _integrity_level(score: int) -> str:
+    if score > 6:
+        return "legendary"
+    if score > 3:
+        return "high"
+    if score > 0:
+        return "medium"
+    return "low"
+
+
+def export_certificate(certificate: Dict[str, object]) -> str:
+    """Augment certificate with metadata and save it to ``exports``.
+
+    Parameters
+    ----------
+    certificate: Dict[str, object]
+        Base certificate produced by :func:`identity.bridge.generate_belief_certificate`.
+
+    Returns
+    -------
+    str
+        Path to the written JSON file.
+    """
+
+    graph: List[Dict[str, object]] = get_memory_graph()
+    traits_summary = sorted({t for node in graph for t in node["traits"]})
+    trait_score = sum(node["score"] for node in graph) if graph else 0
+    frequency = len(graph)
+    vaultfire_output = simulate_passive_yield(trait_score, frequency)
+
+    enriched = dict(certificate)
+    enriched.update(
+        {
+            "integrity_level": _integrity_level(int(certificate.get("integrity_score", 0))),
+            "reward_preview": rewards.get_last_signal(),
+            "traits_summary": traits_summary,
+            "vaultfire_output": vaultfire_output,
+        }
+    )
+
+    timestamp_safe = enriched["timestamp"].replace(":", "-")
+    os.makedirs("exports", exist_ok=True)
+    path = f"exports/belief_certificate_{timestamp_safe}.json"
+    with open(path, "w") as f:
+        json.dump(enriched, f, indent=2)
+    return path
+
+
+__all__ = ["export_certificate"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,16 @@
+import argparse
+import datetime
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from mirror_log import log_sample, self_audit_template
 from vaultfire import rewards
 from memory_graph import update_graph
 from moral_alignment import evaluate_entry
-import datetime
+from identity.bridge import generate_belief_certificate
+from identity.exporter import export_certificate
 
 
 def get_user_input():
@@ -27,4 +35,18 @@ def get_user_input():
 
 
 if __name__ == "__main__":
-    get_user_input()
+    parser = argparse.ArgumentParser(description="Humanity Mirror")
+    parser.add_argument(
+        "--export", action="store_true", help="generate belief proof and export logs"
+    )
+    args = parser.parse_args()
+
+    if args.export:
+        cert = generate_belief_certificate("ghostkey316.eth", "bpow20.cb.id")
+        path = export_certificate(cert)
+        print(f"Belief certificate saved to {path}")
+        signal = rewards.get_last_signal()
+        if signal:
+            print(signal)
+    else:
+        get_user_input()

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,44 @@
+import json
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "src"))
+
+from identity.bridge import generate_belief_certificate
+from identity.exporter import export_certificate
+from memory_graph import update_graph
+from vaultfire import rewards
+
+
+def test_identity_bridge_includes_tags_and_reflections():
+    update_graph("I was honest and kind today.")
+    rewards.calculate("I was honest and kind today.")
+
+    cert = generate_belief_certificate(
+        "ghostkey316.eth", "bpow20.cb.id", biometric_hash="biohash"
+    )
+    assert cert["ens"] == "ghostkey316.eth"
+    assert cert["cb_id"] == "bpow20.cb.id"
+    assert cert["biometric_hash"] == "biohash"
+    assert cert["recent_reflections"]
+    assert "reward_signal" in cert
+
+
+def test_exporter_formats_and_writes_file():
+    update_graph("Another honest reflection full of compassion.")
+    rewards.calculate("Another honest reflection full of compassion.")
+
+    cert = generate_belief_certificate("ghostkey316.eth", "bpow20.cb.id")
+    path = export_certificate(cert)
+    assert os.path.exists(path)
+    with open(path) as f:
+        data = json.load(f)
+
+    assert data["integrity_level"] in {"low", "medium", "high", "legendary"}
+    assert "traits_summary" in data
+    assert "reward_preview" in data
+    assert "vaultfire_output" in data
+
+    os.remove(path)


### PR DESCRIPTION
## Summary
- bridge reflections and rewards to ENS/cb.id anchors with belief certificate data
- export belief proof with integrity levels, traits, and Vaultfire simulation
- add CLI `--export` option and tests for certificate generation and exporting

## Testing
- `pytest tests/test_identity.py -q`
- `python src/main.py --export`


------
https://chatgpt.com/codex/tasks/task_e_6892d337abac8322ad530c79816927e8