### PR TITLE
Add self-audit, streak tracking, and signal engine

### DIFF
--- a/dashboard/templates/signal.html
+++ b/dashboard/templates/signal.html
@@ -1,0 +1,15 @@
+<div id="live-signal">
+  <h2>Live Signal</h2>
+  <div class="traits">
+    <h3>Today's Traits</h3>
+    <ul id="traits-list"></ul>
+  </div>
+  <div class="streaks">
+    <h3>Active Streaks</h3>
+    <ul id="streaks-list"></ul>
+  </div>
+  <div class="signal-level">
+    <h3>Current Signal</h3>
+    <span id="signal-value" class="level-green">0</span>
+  </div>
+</div>

--- a/src/self_audit.py
+++ b/src/self_audit.py
@@ -1,0 +1,49 @@
+from collections import Counter
+from typing import Dict, List
+
+
+def audit_feedback(graph: List[Dict[str, object]], window: int = 5) -> List[str]:
+    """Analyze recent reflections and emit drift messages.
+
+    Args:
+        graph: List of reflection nodes with ``score``, ``sentiment`` and ``traits``.
+        window: Number of recent reflections to scan.
+
+    Returns:
+        List of feedback strings describing moral drift and trends.
+    """
+
+    recent = graph[-window:]
+    if len(recent) < 2:
+        return ["Not enough data for self-audit"]
+
+    messages: List[str] = []
+
+    # Integrity drift based on score difference
+    first_score = recent[0].get("score", 0)
+    last_score = recent[-1].get("score", 0)
+    if last_score != first_score:
+        diff = last_score - first_score
+        level = "severe" if abs(diff) >= 2 else "light"
+        direction = "rising" if diff > 0 else "falling"
+        messages.append(f"Integrity {direction} ({level})")
+
+    # Trait frequency drift
+    half = max(1, len(recent) // 2)
+    first_traits = Counter(t for n in recent[:half] for t in n.get("traits", []))
+    second_traits = Counter(t for n in recent[half:] for t in n.get("traits", []))
+    all_traits = set(first_traits) | set(second_traits)
+    for trait in all_traits:
+        diff = second_traits.get(trait, 0) - first_traits.get(trait, 0)
+        if diff != 0:
+            level = "severe" if abs(diff) >= 2 else "light"
+            direction = "Leaning into" if diff > 0 else "Drifting from"
+            messages.append(f"{direction} {trait} ({level})")
+
+    # Sentiment shift
+    first_sent = recent[0].get("sentiment")
+    last_sent = recent[-1].get("sentiment")
+    if first_sent != last_sent:
+        messages.append(f"Sentiment shift: {first_sent} -> {last_sent}")
+
+    return messages

--- a/src/signal_engine.py
+++ b/src/signal_engine.py
@@ -1,0 +1,44 @@
+import json
+from datetime import datetime
+from typing import Dict, Optional
+
+from streak_tracker import streak_bonus
+
+
+def _growth_summary(current: Dict[str, object], previous: Optional[Dict[str, object]]) -> str:
+    if not previous:
+        return ", ".join(f"+1 {t}" for t in current.get("traits", []))
+
+    summary = []
+    prev_traits = set(previous.get("traits", []))
+    curr_traits = set(current.get("traits", []))
+    for t in curr_traits - prev_traits:
+        summary.append(f"+1 {t}")
+    for t in prev_traits - curr_traits:
+        summary.append(f"-1 {t}")
+    diff = current.get("score", 0) - previous.get("score", 0)
+    if diff:
+        sign = "+" if diff > 0 else "-"
+        summary.append(f"{sign}{abs(diff)} integrity")
+    return ", ".join(summary)
+
+
+def emit_signal(
+    node: Dict[str, object],
+    streak_info: Dict[str, object],
+    prev_node: Optional[Dict[str, object]] = None,
+    path: str = "vaultfire_signal.json",
+) -> Dict[str, object]:
+    bonus = streak_bonus(streak_info.get("streak", 0))
+    multiplier = round(1 + node.get("score", 0) * 0.1 + bonus, 2)
+    data = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "top_traits": node.get("traits", []),
+        "reward_multiplier": multiplier,
+        "growth": _growth_summary(node, prev_node),
+        "streak": streak_info.get("streak", 0),
+        "trait_streaks": streak_info.get("trait_streaks", {}),
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
+    return data

--- a/src/streak_tracker.py
+++ b/src/streak_tracker.py
@@ -1,0 +1,65 @@
+import datetime
+import json
+import os
+from typing import Dict, List
+
+
+DATA_PATH = "streak.json"
+
+
+def _load(path: str = DATA_PATH) -> Dict[str, object]:
+    if os.path.exists(path):
+        with open(path) as f:
+            return json.load(f)
+    return {"last_date": "", "streak": 0, "trait_streaks": {}}
+
+
+def _save(data: Dict[str, object], path: str = DATA_PATH) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def update_streak(date: str = None, traits: List[str] = None, path: str = DATA_PATH) -> Dict[str, object]:
+    if date is None:
+        date = datetime.date.today().isoformat()
+    if traits is None:
+        traits = []
+
+    data = _load(path)
+    last_date = data.get("last_date")
+    streak = data.get("streak", 0)
+    trait_streaks: Dict[str, int] = data.get("trait_streaks", {})
+
+    if last_date:
+        last = datetime.date.fromisoformat(last_date)
+        today = datetime.date.fromisoformat(date)
+        delta = (today - last).days
+        if delta == 1:
+            streak += 1
+        elif delta > 1:
+            streak = 1
+        # if delta == 0: same day, streak unchanged
+    else:
+        streak = 1
+
+    for trait in list(trait_streaks.keys()):
+        if trait not in traits:
+            trait_streaks[trait] = 0
+    for trait in traits:
+        trait_streaks[trait] = trait_streaks.get(trait, 0) + 1
+
+    data = {"last_date": date, "streak": streak, "trait_streaks": trait_streaks}
+    _save(data, path)
+    return data
+
+
+def get_streak(path: str = DATA_PATH) -> Dict[str, object]:
+    return _load(path)
+
+
+def streak_bonus(streak: int) -> float:
+    if streak >= 7:
+        return 0.2
+    if streak >= 3:
+        return 0.1
+    return 0.0

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from datetime import date, timedelta
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "src"))
+
+import memory_graph
+from memory_graph import update_graph
+from self_audit import audit_feedback
+from streak_tracker import update_streak
+
+
+def test_drift_detection_and_streak(tmp_path):
+    memory_graph._MEMORY_GRAPH = []
+
+    update_graph("I was honest and kind.")
+    update_graph("Felt some fear and doubt today.")
+    update_graph("Staying honest with compassion.")
+    update_graph("I was selfish and afraid.")
+    update_graph("Fear returned and I felt doubt.")
+
+    feedback = audit_feedback(memory_graph.get_memory_graph(), window=5)
+    assert any("Integrity" in msg for msg in feedback)
+
+    path = tmp_path / "streak.json"
+    base = date.today()
+    update_streak(date=base.isoformat(), traits=["honesty"], path=str(path))
+    update_streak(date=(base + timedelta(days=1)).isoformat(), traits=["honesty"], path=str(path))
+    data = update_streak(date=(base + timedelta(days=2)).isoformat(), traits=["compassion"], path=str(path))
+    assert data["streak"] == 3
+    assert data["trait_streaks"].get("honesty", 0) == 0
+    assert data["trait_streaks"].get("compassion", 0) == 1

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,0 +1,34 @@
+import json
+import os
+import sys
+from datetime import date
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "src"))
+
+import memory_graph
+from memory_graph import update_graph
+from signal_engine import emit_signal
+from streak_tracker import update_streak
+
+
+def test_signal_output_formatting(tmp_path):
+    memory_graph._MEMORY_GRAPH = []
+    first = update_graph("Honest and kind reflection.")
+    second = update_graph("Fear and doubt appeared.")
+
+    streak_path = tmp_path / "streak.json"
+    streak_info = update_streak(date=date.today().isoformat(), traits=second["traits"], path=str(streak_path))
+
+    out_path = tmp_path / "vaultfire_signal.json"
+    data = emit_signal(second, streak_info, prev_node=first, path=str(out_path))
+
+    with open(out_path) as f:
+        loaded = json.load(f)
+
+    assert "timestamp" in loaded
+    assert loaded["top_traits"] == second["traits"]
+    assert "reward_multiplier" in loaded
+    assert isinstance(loaded["growth"], str)
+    assert loaded["streak"] == streak_info["streak"]


### PR DESCRIPTION
## Summary
- Introduce self-audit engine for detecting integrity shifts, trait drift, and sentiment changes
- Track daily and trait streaks with optional reward bonus
- Emit per-session vaultfire signals and integrate into main workflow with dashboard template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d5a7d9f0832288a70e1e8a81ceda