### PR TITLE
Add Belief Loop Engine with auto-leveling

### DIFF
--- a/dashboard/templates/loop.html
+++ b/dashboard/templates/loop.html
@@ -1,0 +1,17 @@
+<div id="belief-loop">
+  <h2>Belief Loop</h2>
+  <div class="level">
+    <h3>Current Level</h3>
+    <span id="current-level"></span>
+    <div>Next: <span id="next-level"></span></div>
+  </div>
+  <div class="xp">
+    <h3>XP</h3>
+    <div id="xp-bar"></div>
+    <div>+<span id="session-xp"></span> XP this session</div>
+  </div>
+  <div class="trait-evolution">
+    <h3>Trait Evolution Map</h3>
+    <ul id="trait-evolution-list"></ul>
+  </div>
+</div>

--- a/data/levels.json
+++ b/data/levels.json
@@ -1,0 +1,7 @@
+{
+  "1": "Moral Novice",
+  "2": "Ethical Explorer",
+  "3": "Compassionate Thinker",
+  "4": "Conscious Architect",
+  "5": "Belief Master"
+}

--- a/src/loop_engine.py
+++ b/src/loop_engine.py
@@ -1,0 +1,73 @@
+import json
+import os
+from typing import Dict, List
+
+LEVELS_PATH = os.path.join("data", "levels.json")
+STATE_PATH = "loop_state.json"
+
+
+def _load_json(path: str) -> Dict[str, object]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _save_json(data: Dict[str, object], path: str) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def _load_levels(path: str = LEVELS_PATH) -> Dict[int, str]:
+    with open(path) as f:
+        raw = json.load(f)
+    return {int(k): v for k, v in raw.items()}
+
+
+def _trait_evolution(current: List[str], previous: List[str]) -> List[str]:
+    curr = set(current)
+    prev = set(previous)
+    notes: List[str] = []
+    for t in sorted(curr - prev):
+        notes.append(f"{t} emerged")
+    for t in sorted(prev - curr):
+        notes.append(f"{t} faded")
+    return notes
+
+
+def run_loop(
+    reflection_path: str,
+    streak_path: str,
+    signal_path: str,
+    state_path: str = STATE_PATH,
+    levels_path: str = LEVELS_PATH,
+) -> Dict[str, object]:
+    """Run a single belief loop session."""
+
+    reflection = _load_json(reflection_path)
+    streak = _load_json(streak_path)
+    signal = _load_json(signal_path) if os.path.exists(signal_path) else {}
+    prev_state = _load_json(state_path) if os.path.exists(state_path) else {}
+
+    notes = _trait_evolution(
+        reflection.get("traits", []), signal.get("top_traits", [])
+    )
+    xp = streak.get("streak", 0) + reflection.get("score", 0) + len(notes)
+    total_xp = prev_state.get("total_xp", 0) + xp
+
+    levels = _load_levels(levels_path)
+    max_level = max(levels)
+    level = min(max_level, total_xp // 10 + 1)
+    level_name = levels.get(level, "Unknown")
+    next_threshold = level * 10
+
+    state = {
+        "level": level,
+        "level_name": level_name,
+        "xp_gained": xp,
+        "next_level_threshold": next_threshold,
+        "trait_evolution": notes,
+        "vaultfire_multiplier": signal.get("reward_multiplier", 1.0),
+        "total_xp": total_xp,
+    }
+
+    _save_json(state, state_path)
+    return state

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,60 @@
+import json
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "src"))
+
+from loop_engine import run_loop
+
+
+def _write(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def test_loop_engine_xp_level_and_traits(tmp_path):
+    levels_path = tmp_path / "levels.json"
+    _write(
+        levels_path,
+        {"1": "Moral Novice", "2": "Ethical Explorer", "3": "Compassionate Thinker"},
+    )
+
+    reflection_path = tmp_path / "reflection.json"
+    streak_path = tmp_path / "streak.json"
+    signal_path = tmp_path / "signal.json"
+    state_path = tmp_path / "loop_state.json"
+
+    _write(signal_path, {"top_traits": ["honesty"], "reward_multiplier": 1.0})
+    _write(streak_path, {"streak": 3})
+    _write(reflection_path, {"score": 2, "traits": ["honesty", "compassion"]})
+
+    state1 = run_loop(
+        str(reflection_path),
+        str(streak_path),
+        str(signal_path),
+        state_path=str(state_path),
+        levels_path=str(levels_path),
+    )
+
+    assert state1["xp_gained"] == 6
+    assert state1["level"] == 1
+    assert "compassion emerged" in state1["trait_evolution"]
+
+    _write(signal_path, {"top_traits": ["honesty", "compassion"], "reward_multiplier": 1.2})
+    _write(streak_path, {"streak": 4})
+    _write(reflection_path, {"score": 1, "traits": ["honesty"]})
+
+    state2 = run_loop(
+        str(reflection_path),
+        str(streak_path),
+        str(signal_path),
+        state_path=str(state_path),
+        levels_path=str(levels_path),
+    )
+
+    assert state2["xp_gained"] == 6
+    assert state2["level"] == 2
+    assert state2["level_name"] == "Ethical Explorer"
+    assert "compassion faded" in state2["trait_evolution"]


### PR DESCRIPTION
## Summary
- Add Belief Loop Engine that reads reflection, streak and signal files, computes trait evolution and session XP, and auto-levels against a configurable scale
- Introduce `data/levels.json` level definitions and a dashboard template for displaying loop progress
- Cover loop behaviour with tests ensuring XP calculation, level ups, and trait evolution tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d6d6605c83229c6846c377a8d98f