### PR TITLE
Add soul memory archive and query tools

### DIFF
--- a/dashboard/templates/memory.html
+++ b/dashboard/templates/memory.html
@@ -1,0 +1,12 @@
+<div id="soul-memory">
+  <h2>Soul Memory</h2>
+  <div class="timeline">
+    <canvas id="memory-timeline"></canvas>
+  </div>
+  <div class="heatmap" id="trait-heatmap"></div>
+  <div class="filters">
+    <label>Date: <input type="date" id="memory-date"></label>
+    <label>Trait: <input type="text" id="memory-trait" placeholder="trait"></label>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</div>

--- a/src/soul_memory.py
+++ b/src/soul_memory.py
@@ -1,0 +1,102 @@
+"""Persistent archive for reflections and moral state."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Default path for the archive
+ARCHIVE_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "archive.jsonl"
+)
+
+
+@dataclass
+class MemoryEntry:
+    """Represents a single soul memory snapshot."""
+
+    timestamp: str
+    reflection: str
+    trait_summary: Dict[str, Any]
+    vaultfire_signal: Any
+    xp: int
+    level: int
+
+
+def log_memory(
+    reflection: str,
+    trait_summary: Dict[str, Any],
+    vaultfire_signal: Any,
+    xp: int,
+    level: int,
+    *,
+    timestamp: Optional[datetime | str] = None,
+    archive_path: Path | str | None = None,
+) -> MemoryEntry:
+    """Append a new memory entry to the archive.
+
+    Args:
+        reflection: User's written reflection.
+        trait_summary: Summary from trait audit.
+        vaultfire_signal: Signal emitted this session.
+        xp: XP at time of reflection.
+        level: Level at time of reflection.
+        timestamp: Optional timestamp, defaults to current UTC time.
+        archive_path: Optional override path for the archive.
+
+    Returns:
+        MemoryEntry: The entry that was written.
+    """
+
+    if archive_path is None:
+        archive_path = ARCHIVE_PATH
+    archive_path = Path(archive_path)
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if timestamp is None:
+        ts = datetime.utcnow().isoformat()
+    elif isinstance(timestamp, datetime):
+        ts = timestamp.isoformat()
+    else:
+        ts = str(timestamp)
+
+    entry = MemoryEntry(
+        timestamp=ts,
+        reflection=reflection,
+        trait_summary=trait_summary,
+        vaultfire_signal=vaultfire_signal,
+        xp=xp,
+        level=level,
+    )
+
+    with archive_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(asdict(entry)) + "\n")
+
+    return entry
+
+
+def load_archive(archive_path: Path | str | None = None) -> List[Dict[str, Any]]:
+    """Load all memory entries from the archive."""
+
+    if archive_path is None:
+        archive_path = ARCHIVE_PATH
+    archive_path = Path(archive_path)
+
+    if not archive_path.exists():
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    with archive_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                # Skip malformed lines
+                continue
+    return entries

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,1 @@
+# Tools package for CLI utilities.

--- a/src/tools/query_memory.py
+++ b/src/tools/query_memory.py
@@ -1,0 +1,90 @@
+"""CLI utilities to query the soul memory archive."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from soul_memory import ARCHIVE_PATH, load_archive
+
+
+def recall(date: str, path: str | Path = ARCHIVE_PATH) -> Optional[Dict[str, Any]]:
+    """Return the entry that matches a given date (YYYY-MM-DD)."""
+    entries = load_archive(path)
+    for entry in entries:
+        if entry["timestamp"].startswith(date):
+            return entry
+    return None
+
+
+def search_trait(trait: str, path: str | Path = ARCHIVE_PATH) -> List[Dict[str, Any]]:
+    """Return entries where the given trait appears."""
+    trait = trait.lower()
+    results: List[Dict[str, Any]] = []
+    for entry in load_archive(path):
+        # Search in reflection text
+        if trait in entry.get("reflection", "").lower():
+            results.append(entry)
+            continue
+        # Search in trait summary keys
+        summary = entry.get("trait_summary", {})
+        if isinstance(summary, dict):
+            keys = [k.lower() for k in summary.keys()]
+            if trait in keys:
+                results.append(entry)
+    return results
+
+
+def generate_summary(path: str | Path = ARCHIVE_PATH) -> str:
+    """Provide a lightweight summary of the archive."""
+    entries = load_archive(path)
+    if not entries:
+        return "No soul memories recorded."
+
+    start = entries[0]["timestamp"]
+    end = entries[-1]["timestamp"]
+    trait_counter: Counter[str] = Counter()
+    for e in entries:
+        summary = e.get("trait_summary", {})
+        if isinstance(summary, dict):
+            trait_counter.update(summary.keys())
+    top = ", ".join(f"{t}({c})" for t, c in trait_counter.most_common(3))
+    return f"{len(entries)} reflections from {start} to {end}. Top traits: {top}."
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Query Soul Memory Archive")
+    parser.add_argument("--recall", help="Show reflection from given date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--search", nargs=2, metavar=("field", "value"), help="Search archive"
+    )
+    parser.add_argument("--summary", action="store_true", help="Summarize archive")
+    parser.add_argument(
+        "--path", default=ARCHIVE_PATH, help="Path to archive file", type=str
+    )
+    args = parser.parse_args(argv)
+
+    path = args.path
+    if args.recall:
+        entry = recall(args.recall, path)
+        if entry:
+            print(entry["reflection"])
+        else:
+            print("No entry for that date.")
+    elif args.search:
+        field, value = args.search
+        if field == "trait":
+            for e in search_trait(value, path):
+                print(f"{e['timestamp']}: {e['reflection']}")
+        else:
+            print("Unsupported search field.")
+    elif args.summary:
+        print(generate_summary(path))
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(ROOT)
+sys.path.append(os.path.join(ROOT, "src"))
+
+from soul_memory import log_memory, load_archive
+from tools import query_memory
+
+
+def test_archive_write_and_recall(tmp_path):
+    archive = tmp_path / "archive.jsonl"
+    log_memory(
+        "Practiced empathy today",
+        {"empathy": 1},
+        0.5,
+        120,
+        2,
+        timestamp=datetime(2024, 1, 1, 12, 0, 0),
+        archive_path=archive,
+    )
+
+    entries = load_archive(archive)
+    assert len(entries) == 1
+    assert entries[0]["reflection"] == "Practiced empathy today"
+
+    recalled = query_memory.recall("2024-01-01", path=archive)
+    assert recalled is not None
+    assert recalled["xp"] == 120
+
+
+def test_search_trait(tmp_path):
+    archive = tmp_path / "archive.jsonl"
+    log_memory(
+        "Helped a friend",
+        {"empathy": 1},
+        0.7,
+        50,
+        1,
+        timestamp="2024-01-01T00:00:00",
+        archive_path=archive,
+    )
+    log_memory(
+        "Spoke honestly",
+        {"honesty": 1},
+        0.6,
+        60,
+        1,
+        timestamp="2024-01-02T00:00:00",
+        archive_path=archive,
+    )
+
+    results = query_memory.search_trait("empathy", path=archive)
+    assert len(results) == 1
+    assert results[0]["trait_summary"].get("empathy") == 1


### PR DESCRIPTION
## Summary
- add `soul_memory` module that records reflections, trait summaries, signals, xp and level to `data/archive.jsonl`
- provide `tools/query_memory` CLI with commands to recall by date, search traits and summarize archive
- include Soul Memory dashboard tab template and tests for archive and query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d82a92f08322ac24eb5a5c52a15d