### PR TITLE
feat: add AI mirror engine

### DIFF
--- a/dashboard/templates/ai_mirror.html
+++ b/dashboard/templates/ai_mirror.html
@@ -1,0 +1,4 @@
+<div id="ai-mirror">
+  <h2>AI Mirror</h2>
+  <p>This panel reflects on past memories. Use the CLI via <code>mirror.py</code> to ask questions.</p>
+</div>

--- a/mirror.py
+++ b/mirror.py
@@ -1,0 +1,37 @@
+"""CLI utility for the AI Mirror reflection engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.mirror_engine import MirrorEngine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interact with the AI Mirror")
+    parser.add_argument("--ask", dest="ask", type=str, required=True, help="Question to pose to the mirror")
+    parser.add_argument("--archive", dest="archive", type=str, default=None, help="Optional archive path")
+    args = parser.parse_args()
+
+    engine = MirrorEngine(args.archive)
+    matches = engine.recall(args.ask)
+
+    output = []
+    for m in matches:
+        output.append(
+            {
+                "timestamp": m.timestamp,
+                "reflection": m.reflection,
+                "echo": m.echo,
+                "xp_then": m.xp,
+                "xp_diff": m.xp_diff,
+                "trait_drift": m.trait_drift,
+            }
+        )
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mirror_engine.py
+++ b/src/mirror_engine.py
@@ -1,0 +1,107 @@
+"""AI Mirror module for reflective dialogue using past soul memories."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .soul_memory import load_archive
+
+
+@dataclass
+class MirrorMatch:
+    """Represents a recalled memory and commentary about its evolution."""
+
+    timestamp: str
+    reflection: str
+    trait_summary: Dict[str, Any]
+    xp: int
+    level: int
+    similarity: float
+    xp_diff: int
+    trait_drift: Dict[str, float]
+
+    @property
+    def echo(self) -> str:
+        return f"Who you were on {self.timestamp} would say: {self.reflection}"  # noqa: D401
+
+
+class MirrorEngine:
+    """Recall past memories similar to a prompt and generate evolution notes."""
+
+    def __init__(self, archive_path: Optional[str | Path] = None):
+        self.entries = load_archive(archive_path)
+        self.current = self.entries[-1] if self.entries else None
+
+    # --- internal helpers -------------------------------------------------
+    _WORD_RE = re.compile(r"\w+")
+
+    @classmethod
+    def _vectorize(cls, text: str) -> Counter:
+        tokens = cls._WORD_RE.findall(text.lower())
+        return Counter(tokens)
+
+    @staticmethod
+    def _cosine(a: Counter, b: Counter) -> float:
+        if not a or not b:
+            return 0.0
+        dot = sum(v * b.get(k, 0) for k, v in a.items())
+        norm_a = math.sqrt(sum(v * v for v in a.values()))
+        norm_b = math.sqrt(sum(v * v for v in b.values()))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    # --- public API -------------------------------------------------------
+    def recall(self, prompt: str, top_n: int = 3) -> List[MirrorMatch]:
+        """Return the top ``n`` memories matching ``prompt``.
+
+        If the archive is empty this returns an empty list.
+        """
+
+        if not self.entries:
+            return []
+
+        prompt_vec = self._vectorize(prompt)
+        scored: List[MirrorMatch] = []
+        for entry in self.entries:
+            reflection_vec = self._vectorize(entry.get("reflection", ""))
+            sim = self._cosine(prompt_vec, reflection_vec)
+            xp_then = entry.get("xp", 0)
+            xp_now = self.current.get("xp", 0) if self.current else xp_then
+            trait_drift = self._trait_drift(entry)
+            scored.append(
+                MirrorMatch(
+                    timestamp=entry.get("timestamp", ""),
+                    reflection=entry.get("reflection", ""),
+                    trait_summary=entry.get("trait_summary", {}),
+                    xp=xp_then,
+                    level=entry.get("level", 0),
+                    similarity=sim,
+                    xp_diff=xp_now - xp_then,
+                    trait_drift=trait_drift,
+                )
+            )
+
+        scored.sort(key=lambda m: m.similarity, reverse=True)
+        return scored[:top_n]
+
+    # --- utilities --------------------------------------------------------
+    def _trait_drift(self, past_entry: Dict[str, Any]) -> Dict[str, float]:
+        """Compute drift in numeric trait values from ``past_entry`` to current."""
+
+        if not self.current:
+            return {}
+
+        drift: Dict[str, float] = {}
+        past_traits = past_entry.get("trait_summary", {})
+        current_traits = self.current.get("trait_summary", {})
+        for trait, past_val in past_traits.items():
+            cur_val = current_traits.get(trait)
+            if isinstance(past_val, (int, float)) and isinstance(cur_val, (int, float)):
+                drift[trait] = cur_val - past_val
+        return drift

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from src.mirror_engine import MirrorEngine
+
+
+def make_entry(ts, text, traits, xp, level):
+    return {
+        "timestamp": ts,
+        "reflection": text,
+        "trait_summary": traits,
+        "vaultfire_signal": None,
+        "xp": xp,
+        "level": level,
+    }
+
+
+def test_recall_returns_top_matches(tmp_path):
+    archive = tmp_path / "archive.jsonl"
+    entries = [
+        make_entry("2024-01-01T00:00:00", "I believe in loyalty and honor.", {"loyalty": 5, "courage": 3}, 100, 1),
+        make_entry(
+            "2024-02-01T00:00:00",
+            "Focusing on discipline helps with loyalty.",
+            {"discipline": 4, "loyalty": 4},
+            150,
+            2,
+        ),
+        make_entry(
+            "2024-03-01T00:00:00",
+            "Sometimes loyalty conflicts with truth.",
+            {"truth": 5, "loyalty": 3},
+            200,
+            3,
+        ),
+    ]
+    with archive.open("w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+    engine = MirrorEngine(archive)
+    matches = engine.recall("What did I used to believe about loyalty?")
+
+    assert len(matches) == 3
+    assert matches[0].reflection.startswith("I believe in loyalty")
+    # Current entry XP is 200, so first entry should show diff of 100
+    assert matches[0].xp_diff == 100
+    assert matches[0].trait_drift["loyalty"] == -2  # from 5 to 3


### PR DESCRIPTION
## Summary
- add MirrorEngine to recall similar soul memories, show echo and evolution
- expose engine via `mirror.py` script and basic `ai_mirror.html` panel
- test that recall returns top matches with XP and trait drift

## Testing
- `pytest -q`
- `python mirror.py --ask "What did I used to believe about loyalty?"`


------
https://chatgpt.com/codex/tasks/task_e_6892d97b61688322aae8897655dc75f7